### PR TITLE
ROS Fuerte Fix

### DIFF
--- a/youbot_common/youbot_description/examples/cartesian_compliance_control_test.cpp
+++ b/youbot_common/youbot_description/examples/cartesian_compliance_control_test.cpp
@@ -62,7 +62,7 @@ void publishTf() {
     while(ros::ok()) {
         if (mutex) {
             tf::Vector3 position(tipPose.position.x, tipPose.position.y, tipPose.position.z);
-            btQuaternion orientation;
+            tf::Quaternion orientation;
             tf::quaternionMsgToTF(tipPose.orientation, orientation);
             tf::Transform transform(orientation, position);
             string parentFrameId = tipPose.base_frame_uri;
@@ -73,15 +73,15 @@ void publishTf() {
     }
 }
 
-void ypr2Quat(double yaw, double pitch, double roll, btQuaternion& quanternion) {
-        btMatrix3x3 rotMatrix;
-        rotMatrix.setEulerYPR(btScalar(yaw), btScalar(pitch), btScalar(roll));
+void ypr2Quat(double yaw, double pitch, double roll, tf::Quaternion& quanternion) {
+        tf::Matrix3x3 rotMatrix;
+        rotMatrix.setEulerYPR(tfScalar(yaw), tfScalar(pitch), tfScalar(roll));
         rotMatrix.getRotation(quanternion);
 }
 
 void setCartesianVectorMsg(brics_actuator::CartesianPose& tipPose,
                            const brics_actuator::CartesianVector& tipPosition,
-                           const btQuaternion& tipOrientation,
+                           const tf::Quaternion& tipOrientation,
                            const string baseFrameUri,
                            const string targetFrameUri,
                            ros::Time timeStamp) {
@@ -99,7 +99,7 @@ void test1(const ros::Publisher& armCommandPublisher) {
 
     for (int i = 0; i < 0; i++) {
     brics_actuator::CartesianVector tipPosition;
-    btQuaternion tipOrientation;
+    tf::Quaternion tipOrientation;
 
     //ref. position 1
     tipPosition.x = 0.0;
@@ -189,7 +189,7 @@ int main(int argc, char **argv) {
     ros::Publisher armCommandPublisher;
 
     brics_actuator::CartesianVector tipPosition;
-    btQuaternion tipOrientation;
+    tf::Quaternion tipOrientation;
 
     tipPosition.x = 0;
     tipPosition.y = 0;

--- a/youbot_common/youbot_description/src/cartesian_compliance_control.cpp
+++ b/youbot_common/youbot_description/src/cartesian_compliance_control.cpp
@@ -58,7 +58,7 @@ CartesianComplianceController* CartesianComplianceControllerDebug::getController
 
 void CartesianComplianceControllerDebug::toTransformMatrix(double* tf, tf::Transform& trans) {
 	trans.setOrigin(tf::Vector3(tf[3], tf[7], tf[11]));
-	btMatrix3x3 rotMatrix(tf[0], tf[1], tf[2],
+	tf::Matrix3x3 rotMatrix(tf[0], tf[1], tf[2],
 			tf[4], tf[5], tf[6],
 			tf[8], tf[9], tf[10]);
 	tf::Quaternion quat;
@@ -69,7 +69,7 @@ void CartesianComplianceControllerDebug::toTransformMatrix(double* tf, tf::Trans
 void CartesianComplianceControllerDebug::publishTf(double* tf, string parent, string child) {
 	/*tf::Transform trans;
 	trans.setOrigin(tf::Vector3(tf[3], tf[7], tf[11]));
-	btMatrix3x3 rotMatrix(tf[0], tf[1], tf[2],
+	tf::Matrix3x3 rotMatrix(tf[0], tf[1], tf[2],
 			tf[4], tf[5], tf[6],
 			tf[8], tf[9], tf[10]);
 	tf::Quaternion quat;
@@ -333,11 +333,11 @@ void CartesianComplianceController::starting() {
 void CartesianComplianceController::update20SimControl() {
 
     if (!locked) {
-        btQuaternion quat;
+        tf::Quaternion quat;
         tf::quaternionMsgToTF(currentBasePose.orientation, quat);
 
         double ypr[3];
-        btMatrix3x3(quat).getEulerYPR(ypr[0], ypr[1], ypr[2]);
+        tf::Matrix3x3(quat).getEulerYPR(ypr[0], ypr[1], ypr[2]);
 
         u[0] = ypr[0]; //is not active
      //  ROS_INFO("X: %f\n", u[0]);
@@ -451,9 +451,9 @@ void CartesianComplianceController::positionCommand(const brics_actuator::Cartes
 	this->position[1] = tipPosition.y;
 	this->position[2] = tipPosition.z;
 
-	btQuaternion quaternion;
+	tf::Quaternion quaternion;
 	tf::quaternionMsgToTF(tipOrientation, quaternion);
-	btMatrix3x3(quaternion).getEulerYPR(orientationYPR[0], orientationYPR[1], orientationYPR[2]);
+	tf::Matrix3x3(quaternion).getEulerYPR(orientationYPR[0], orientationYPR[1], orientationYPR[2]);
 
 }
 


### PR DESCRIPTION
Please consider the following fix which allows youbot_common to compile/run on ROS Fuerte. The namespace has been changed in the Bullet/TF packages which requires a few quick fixes for any files that use them. To fix, I simply had to run "rosrun tf bullet_migration_sed.py" inside the youbot_common package. 
