### PR TITLE
fixed bug of not existing dependency

### DIFF
--- a/youbot_perception/tower_of_hanoi_sdk/manifest.xml
+++ b/youbot_perception/tower_of_hanoi_sdk/manifest.xml
@@ -14,7 +14,7 @@
   <depend package="rospy"/>
   <depend package="sensor_msgs"/>
   <depend package="geometry_msgs"/>
-  <depend package="geometric_shapes_msgs"/>
+  <depend package="arm_navigation_msgs"/>
   <depend package="visualization_msgs"/>
   <depend package="image_transport"/>
   <depend package="pcl"/>

--- a/youbot_perception/tower_of_hanoi_sdk/msg/SceneObject.msg
+++ b/youbot_perception/tower_of_hanoi_sdk/msg/SceneObject.msg
@@ -2,5 +2,5 @@
 uint32 id
 uint32 parentId
 geometry_msgs/TransformStamped transform
-geometric_shapes_msgs/Shape shape 
+arm_navigation_msgs/Shape shape 
 Attribute[] attributes

--- a/youbot_perception/tower_of_hanoi_sdk/src/WorldModelNode.cpp
+++ b/youbot_perception/tower_of_hanoi_sdk/src/WorldModelNode.cpp
@@ -150,7 +150,7 @@ public:
 			BRICS_3D::RSG::Box::BoxPtr tmpBox = boost::dynamic_pointer_cast<Box>(resultObjects[i].shape);
 
 			if ( tmpBox != 0) {
-				tmpSceneObject.shape.type = geometric_shapes_msgs::Shape::BOX; //TODO support multible shapes
+				tmpSceneObject.shape.type = arm_navigation_msgs::Shape::BOX; //TODO support multible shapes
 				tmpSceneObject.shape.dimensions.resize(3);
 				tmpSceneObject.shape.dimensions[0] = tmpBox->getSizeX();
 				tmpSceneObject.shape.dimensions[1] = tmpBox->getSizeY();


### PR DESCRIPTION
in electric the Shape.msg moved from the "geometric_shapes_msgs" package to the "arm_navigation_msgs".
