### PR TITLE
Add joint limits of the arm/gripper to the yaml config files

### DIFF
--- a/youbot_common/youbot_description/controller/arm_joint_position_control.yaml
+++ b/youbot_common/youbot_description/controller/arm_joint_position_control.yaml
@@ -23,3 +23,20 @@ arm_controller:
     arm_joint_5:
       p: 10
       d: 2.0
+  
+  limits:
+    arm_joint_1:
+      min: 0.0100692
+      max: 5.84014
+	arm_joint_2:
+      min: 0.0100692
+      max: 2.61799
+    arm_joint_3:
+      min: -5.02655
+      max: -0.015708
+    arm_joint_4:
+      min: 0.0221239
+      max: 3.4292
+    arm_joint_5:
+      min: 0.110619
+      max: 5.64159   

--- a/youbot_common/youbot_description/controller/arm_joint_universal_control.yaml
+++ b/youbot_common/youbot_description/controller/arm_joint_universal_control.yaml
@@ -23,3 +23,20 @@ arm_controller:
     arm_joint_5:
       p: 10
       d: 1
+  
+  limits:
+    arm_joint_1:
+      min: 0.0100692
+      max: 5.84014
+	arm_joint_2:
+      min: 0.0100692
+      max: 2.61799
+    arm_joint_3:
+      min: -5.02655
+      max: -0.015708
+    arm_joint_4:
+      min: 0.0221239
+      max: 3.4292
+    arm_joint_5:
+      min: 0.110619
+      max: 5.64159

--- a/youbot_common/youbot_description/controller/gripper_joint_position_control.yaml
+++ b/youbot_common/youbot_description/controller/gripper_joint_position_control.yaml
@@ -12,3 +12,11 @@ gripper_controller:
       p: 10
       d: 2.0
 
+    
+  limits:
+    gripper_finger_joint_l:
+      min: 0.0
+      max: 0.0115
+	gripper_finger_joint_r:
+      min: 0
+      max: 0.0115


### PR DESCRIPTION
I added the limits of each joint to the yaml files so that they will be uploaded to the parameter server. 

We did this because we do not get a feedback if a published joint configuration (on topic "position_command") can be reached or not from the ROS Wrapper. Only a debug output indicate that the one joint might be in the limits. 

This caused problems in our arm action server since it publishes the joint configuration and waits until it is reached. But the driver will not move the arm (since the configuration is not valid) and the arm action server blocks until the position is reached.

With the information on the parameter, we can check beforehand if the configuration is valid and can be reached by the arm. And it might be also useful for other components, I guess.
