### PR TITLE
Wrong P value of the position controller in simulation and conflicting namespaces

### DIFF
--- a/youbot_common/youbot_description/controller/arm_joint_universal_control.yaml
+++ b/youbot_common/youbot_description/controller/arm_joint_universal_control.yaml
@@ -9,17 +9,17 @@ arm_controller:
      
   gains:
     arm_joint_1:
-      p: 10
+      p: 1000
       d: 1
     arm_joint_2:
-      p: 10
+      p: 1000
       d: 1
     arm_joint_3: 
-      p: 10
+      p: 1000
       d: 1
     arm_joint_4:
-      p: 10
+      p: 1000
       d: 1
     arm_joint_5:
-      p: 10
+      p: 1000
       d: 1

--- a/youbot_common/youbot_description/controller_plugins.xml
+++ b/youbot_common/youbot_description/controller_plugins.xml
@@ -1,5 +1,5 @@
 <library path="lib/libjoint_position_control">
-  <class name="youbot_description/JointPositionController" type="controller::JointPositionController" base_class_type="pr2_controller_interface::Controller" />
+  <class name="youbot_description/JointPositionController" type="youbotcontroller::JointPositionController" base_class_type="pr2_controller_interface::Controller" />
 </library>
 <library path="lib/libyoubot_universal_control">
   <class name="youbot_description/YouBotUniversalController" type="controller::YouBotUniversalController" base_class_type="pr2_controller_interface::Controller" />

--- a/youbot_common/youbot_description/include/joint_position_control.h
+++ b/youbot_common/youbot_description/include/joint_position_control.h
@@ -46,7 +46,7 @@
 #include <pr2_controller_interface/controller.h>
 #include "brics_actuator/JointPositions.h"
 
-namespace controller {
+namespace youbotcontroller {
 
 class JointPositionController : public pr2_controller_interface::Controller {
 public:

--- a/youbot_common/youbot_description/src/joint_position_control.cpp
+++ b/youbot_common/youbot_description/src/joint_position_control.cpp
@@ -46,9 +46,9 @@
 #include "pluginlib/class_list_macros.h"
 #include "angles/angles.h"
 
-PLUGINLIB_DECLARE_CLASS(youbot_description, JointPositionController, controller::JointPositionController, pr2_controller_interface::Controller)
+PLUGINLIB_DECLARE_CLASS(youbot_description, JointPositionController, youbotcontroller::JointPositionController, pr2_controller_interface::Controller)
 
-namespace controller
+namespace youbotcontroller
 {
 
 JointPositionController::JointPositionController()


### PR DESCRIPTION
Hi,
we have encountered two problems with your software and fixed it with these two commits. 

First the P value of the position controller for arm was to small to get the arm working in simulation. (Is this regulator also used on the real robot? If yes you have to double check the values.)

Second there was a conflict with the gripper controller in gazebo. The PR2 controllers have the same namespace and class name. We renamed the namespace of the youbot controllers. Please consider  to rename also the namespaces of the arm and base controllers.

regards
Jan
