### PR TITLE
Fixed youbot_oodl bugs with multi-arm systems, added namespacing and more

### DIFF
--- a/youbot_drivers/youbot_oodl/launch/command.txt
+++ b/youbot_drivers/youbot_oodl/launch/command.txt
@@ -1,3 +1,0 @@
-#source ~/ros/setup.sh
-source /opt/ros/cturtle/setup.sh
-rosrun youbot_oodl youbot_oodl

--- a/youbot_drivers/youbot_oodl/launch/start_youbot_oodl_driver
+++ b/youbot_drivers/youbot_oodl/launch/start_youbot_oodl_driver
@@ -10,6 +10,5 @@
 # NOTE: setup.sh is assumed to be in ~/ros/setup.sh
 # ---- 
 
-sudo bash command.txt #the beneath commands need to be in some ASCII file (command.txt), otherwise no output can be seen, as all commands would be executed in a subshell
-#source ~/ros/setup.sh
-#rosrun youbot_oodl youbot_oodl
+echo "Please run 'roslaunch youbot_oodl youbot_oodl_driver.launch' instead."
+

--- a/youbot_drivers/youbot_oodl/launch/youbot_joint_state_publisher.launch
+++ b/youbot_drivers/youbot_oodl/launch/youbot_joint_state_publisher.launch
@@ -11,11 +11,11 @@
 	<!-- start robot_state_publisher assuming /joint_states is not the default topic and the drivers default topics are used -->
 	<!--
 	<node pkg="robot_state_publisher" type="state_publisher" name="robot_arm_state_publisher" output="screen">
-		<remap from="joint_states" to="arm_1/joint_states"/> 
+		<remap from="joint_states" to="youbot-manipulator/joint_states"/> 
 	</node>
 
 	<node pkg="robot_state_publisher" type="state_publisher" name="robot_base_state_publisher" output="screen">
-		<remap from="joint_states" to="base/joint_states"/> 
+		<remap from="joint_states" to="youbot-base/joint_states"/> 
 	</node>
 	-->
 	

--- a/youbot_drivers/youbot_oodl/launch/youbot_oodl_driver.launch
+++ b/youbot_drivers/youbot_oodl/launch/youbot_oodl_driver.launch
@@ -13,17 +13,47 @@ or enable the USE_SETCAP flag in the cmake file and recompile again.
 <launch>
 
 	<!-- Set relevant parameters. -->
-	<param name="youBotHasBase" type="bool" value="true"/>
-	<param name="youBotHasArm" type="bool" value="true"/> 
+	<param name="youBotHasBase" type="bool" value="false"/>
+	<param name="youBotHasArms" type="bool" value="true"/> 
 	<param name="youBotDriverCycleFrequencyInHz" type="double" value="50.0"/>
 
-	<!-- Start the driver. NOTE: Every joint topic is mapped mapped to /joint_states, for convenience.
-	In case one wants to keep the default name just comment out the remap statements. -->
-	<node name="youbot_oodl_driver" pkg="youbot_oodl" type="youbot_oodl" output="screen">
-		<remap from="base/joint_states" to="joint_states"/> 
-		<remap from="arm_1/joint_states" to="joint_states" /> 
-		<!--<remap from="arm_2/joint_states" to="joint_states" />-->
-	</node>
+
+	<!-- 
+	  Initialize youBot arms by name. Each named arm must have a matching config
+	  file. For example, the entry:	 
+		  <param name="youBotArmName1" type="str" value="MyArm"/>
+	  will attempt to initialize an arm using the config file "MyArm.cfg" in your
+	  default configuration path.
+
+	  To initialize multiple arms, simply define parameters naming each of them,
+	  beginning with the parameter "youBotArmName1", then "youBotArmName2", etc.
+	-->
+	
+	<!-- Default name values --> 
+	<param name="youBotBaseName" type="str" value="youbot-base"/>
+	<param name="youBotArmName1" type="str" value="youbot-manipulator"/>
+	
+
+	<!-- Start the driver. NOTE: Every joint topic is mapped to armName/joint_states -->
+	<node name="youbot_oodl_driver" pkg="youbot_oodl" type="youbot_oodl" output="screen"/>
+
+
+        <!-- start robot state publishers (REPLACES NEED FOR SEPARATE youbot_description LAUNCH FILES) -->
+
+	<!-- When customizing this for your robot setup, make sure you have a group defined for each base or arm
+	     that is defined above. -->
+
+	<group ns="youbot-base">
+	        <param name="robot_description" command="$(find xacro)/xacro.py '$(find youbot_description)/robots/youbot_base.urdf.xacro'"/>
+	        <param name="publish_frequency" type="double" value="50.0" />
+	        <node pkg="robot_state_publisher" type="state_publisher" name="rob_st_pub" />
+	</group>
+
+        <group ns="youbot-manipulator">
+        	<param name="robot_description" command="$(find xacro)/xacro.py '$(find youbot_description)/robots/youbot_arm.urdf.xacro'"/>
+                <node pkg="robot_state_publisher" type="state_publisher" name="rob_st_pub"/>
+        </group>
+
 
 </launch>
 

--- a/youbot_drivers/youbot_oodl/src/YouBotConfiguration.cpp
+++ b/youbot_drivers/youbot_oodl/src/YouBotConfiguration.cpp
@@ -108,6 +108,14 @@ YouBotConfiguration::YouBotConfiguration() {
 }
 
 YouBotConfiguration::~YouBotConfiguration() {
+	std::vector<YouBotArmConfiguration*>::iterator iter;
+	for (iter = youBotArmConfigurations.begin(); iter != youBotArmConfigurations.end(); ++iter) {
+		YouBotArmConfiguration *config = *iter;
+		delete config;
+		config = NULL;
+	}
+
+
 	youBotArmConfigurations.clear();
 	armNameToArmIndexMapping.clear();
 }

--- a/youbot_drivers/youbot_oodl/src/YouBotConfiguration.h
+++ b/youbot_drivers/youbot_oodl/src/YouBotConfiguration.h
@@ -174,7 +174,7 @@ public:
 	YouBotBaseConfiguration baseConfiguration;
 
 	/// A youbot system has one or more arms
-	std::vector<YouBotArmConfiguration> youBotArmConfigurations;
+	std::vector<YouBotArmConfiguration*> youBotArmConfigurations;
 	std::map<std::string, int> armNameToArmIndexMapping;
 };
 


### PR DESCRIPTION
Here are the updates I've made to the youbot_oodl code-- hopefully others find them helpful!

Updated youbot_oodl driver to properly support multiple arms being initialized. Previously, the arm initialized last would override all ethercat joint entries for previous arms. This meant joint_states messages for the last initialized arm were being broadcasted as the joint_states messages for all arms in the system, which could be dangerous if unnoticed before handing control to autonomous software.

Added proper namespacing to ROS topics for initialized base/arms, so they now publish within the topic /armName/\* (e.g., /armName/joint_states). This will avoid joint name collisions on multi-arm systems.

Changed YouBotConfiguration::youBotArmConfigurations to be a vector of YouBotArmConfiguration pointers, and updated youbot_oodl package code to reflect this change.

youbot_oodl driver can now be configured entirely via ROS launch files, rather than requiring the user to make edits in the youbot_oodl.cpp file to define their configuration/system.

Added debugging information on arm initialization to give user more information about how their arms are configured at runtime.

Updated instructions for starting the youbot_oodl driver.

Updated youbot_oodl launch file to include youbot_description information, so the user only needs to start one process. It seems rare that one would have an OODL configuration that describes something different from what he/she would want description information published about. Instructions for how to generalize this to particular users' configurations is included in the youbot_oodl_driver.launch file.
