### PR TITLE
remove warning (interia not allowed in base_footprint) and drag base_footprint down to the ground

### DIFF
--- a/youbot_common/youbot_description/urdf/youbot_base/base.urdf.xacro
+++ b/youbot_common/youbot_description/urdf/youbot_base/base.urdf.xacro
@@ -44,12 +44,6 @@
 	<xacro:macro name="youbot_base" params="name">
 		
 		<link name="${name}_footprint">
-      			<inertial>
-        			<mass value="0.1" />
-        			<origin xyz="0 0 ${-base_size_z / 2.0}" rpy="0 0 0" />
-        			<inertia ixx="1.0" ixy="0.0" ixz="0.0"
-                 			iyy="1.0" iyz="0.0" izz="1.0" />
-      				</inertial>
       			<visual>
         			<origin xyz="0 0 0" rpy="0 0 0" />
         			<geometry>
@@ -66,7 +60,7 @@
     		</link>
 
     		<joint name="${name}_footprint_joint" type="fixed">
-      			<origin xyz="0 0 0" rpy="0 0 0" />
+      			<origin xyz="0 0 0.08" rpy="0 0 0" />
       			<child link="${name}_link" />
       			<parent link="${name}_footprint"/>
     		</joint>


### PR DESCRIPTION
- there was always a warning when launching that interia is not allowed in the basefootprint
- and we dragged the base_footprint down to the ground that there is at least one reference point a ground level. This is useful e.g. if you want to define a ROI for perception.

Can you also pick this to the master. 
